### PR TITLE
Fix crash in banded_ssw

### DIFF
--- a/src/ssw.c
+++ b/src/ssw.c
@@ -651,7 +651,7 @@ static cigar* banded_sw (const int8_t* ref,
 			for (j = 1; j <= u; j ++) h_b[j] = h_c[j];
 		}
 		band_width *= 2;
-	} while (LIKELY(max < score));
+	} while (LIKELY(max < score) && LIKELY(band_width <= readLen));
 	band_width /= 2;
 
 	// trace back


### PR DESCRIPTION
The loop for banded_sw sometimes cannot achieve the maximum score so it just keeps doubling the bandwidth size indefinitely until the program crashes.  I'm not sure what the best fix is here but I simply bounded the loop as follows:
The original loop in banded_sw looks like
do {
..
} while (LIKELY(max < score);

I changed this to 
do {
} while (LIKELY(max < score) && LIKELY(band_width <= readLen));

As I understand it, band_width > readLen doesn't make sense anyway so I think this is a reasonable fix.